### PR TITLE
implemented economy

### DIFF
--- a/src/app/(protected)/(user)/f/[forecastId]/actions.ts
+++ b/src/app/(protected)/(user)/f/[forecastId]/actions.ts
@@ -2,7 +2,7 @@
 
 import { auth } from "@/auth";
 import Router from "@/constants/router";
-import { ForecastType } from "@/generated/prisma";
+import { ForecastType, LedgerKind } from "@/generated/prisma"; // [ECONOMY] Added LedgerKind import
 import {
   ActionState,
   createErrorState,
@@ -22,6 +22,14 @@ import {
 } from "@/services/predictions";
 import { revalidatePath } from "next/cache";
 
+// [ECONOMY] Import finance helpers
+import {
+  CENTS,
+  createLedgerEntry,
+  ensureStartingBalancesForUser,
+  getUserBalanceCents,
+} from "@/services/finance";
+
 type PredictionFormData = {
   value: string;
   confidence: string;
@@ -31,6 +39,9 @@ type PredictionFormData = {
   equityInvestment: string;
   debtFinancing: string;
 };
+
+// [ECONOMY] Per-prediction cap (still 20M per investment type)
+const MAX_INVEST_PER_PREDICTION = 20_000_000;
 
 export async function createPredictionAction(
   forecastId: string,
@@ -45,6 +56,9 @@ export async function createPredictionAction(
       _form: ["You must be logged in to submit a prediction"],
     });
   }
+
+  // [ECONOMY] Ensure user has their starting $1B (idempotent)
+  await ensureStartingBalancesForUser(session.user.id);
 
   // 2. Extract form data
   const rawData = extractFormData(formData, [
@@ -92,7 +106,7 @@ export async function createPredictionAction(
     });
   }
 
-  // 4. Validate business rules
+  // 4. Validate business rules (domain-level, non-money)
   const businessValidation = await validatePredictionCreation({
     ...validation.data,
     userId: session.user.id,
@@ -110,11 +124,157 @@ export async function createPredictionAction(
     });
   }
 
-  // 5. Create prediction
+  // ───────────────────────────────────────────────────────────────
+  // [ECONOMY] Money rules & credit line checks
+  // ───────────────────────────────────────────────────────────────
+  const equityInvestment = validation.data.equityInvestment ?? 0; // dollars
+  const debtFinancing = validation.data.debtFinancing ?? 0;       // dollars
+
+  // Non-negative sanity check (in case schema ever changes)
+  if (equityInvestment < 0 || debtFinancing < 0) {
+    return createErrorState(
+      { _form: ["Investments cannot be negative"] },
+      {
+        value: validation.data.value,
+        confidence: validation.data.confidence?.toString() || "",
+        reasoning: validation.data.reasoning || null,
+        method: validation.data.method || null,
+        estimatedTime: validation.data.estimatedTime?.toString() || "",
+        equityInvestment: equityInvestment.toString(),
+        debtFinancing: debtFinancing.toString(),
+      }
+    );
+  }
+
+  // Per-prediction caps (20M each)
+  if (equityInvestment > MAX_INVEST_PER_PREDICTION) {
+    return createErrorState(
+      {
+        _form: [
+          `Equity investment cannot exceed $${MAX_INVEST_PER_PREDICTION.toLocaleString()}`,
+        ],
+      },
+      {
+        value: validation.data.value,
+        confidence: validation.data.confidence?.toString() || "",
+        reasoning: validation.data.reasoning || null,
+        method: validation.data.method || null,
+        estimatedTime: validation.data.estimatedTime?.toString() || "",
+        equityInvestment: equityInvestment.toString(),
+        debtFinancing: debtFinancing.toString(),
+      }
+    );
+  }
+
+  if (debtFinancing > MAX_INVEST_PER_PREDICTION) {
+    return createErrorState(
+      {
+        _form: [
+          `Debt financing cannot exceed $${MAX_INVEST_PER_PREDICTION.toLocaleString()}`,
+        ],
+      },
+      {
+        value: validation.data.value,
+        confidence: validation.data.confidence?.toString() || "",
+        reasoning: validation.data.reasoning || null,
+        method: validation.data.method || null,
+        estimatedTime: validation.data.estimatedTime?.toString() || "",
+        equityInvestment: equityInvestment.toString(),
+        debtFinancing: debtFinancing.toString(),
+      }
+    );
+  }
+
+  // Fetch current cash balance in cents
+  const balanceCents = await getUserBalanceCents(session.user.id);
+  const equityCents = CENTS(equityInvestment);
+  const debtCents = CENTS(debtFinancing);
+
+  // Equity must be fully covered by current cash
+  if (equityCents > balanceCents) {
+    return createErrorState(
+      { _form: ["Not enough cash to make this equity investment"] },
+      {
+        value: validation.data.value,
+        confidence: validation.data.confidence?.toString() || "",
+        reasoning: validation.data.reasoning || null,
+        method: validation.data.method || null,
+        estimatedTime: validation.data.estimatedTime?.toString() || "",
+        equityInvestment: equityInvestment.toString(),
+        debtFinancing: debtFinancing.toString(),
+      }
+    );
+  }
+
+  // Debt line can be 100% of current balance
+  const maxBorrowCents = balanceCents; // 100% of balance
+  if (debtCents > maxBorrowCents) {
+    return createErrorState(
+      { _form: ["Debt financing exceeds your available credit limit"] },
+      {
+        value: validation.data.value,
+        confidence: validation.data.confidence?.toString() || "",
+        reasoning: validation.data.reasoning || null,
+        method: validation.data.method || null,
+        estimatedTime: validation.data.estimatedTime?.toString() || "",
+        equityInvestment: equityInvestment.toString(),
+        debtFinancing: debtFinancing.toString(),
+      }
+    );
+  }
+
+  // 5. Create prediction (domain object)
   await createPrediction({
     ...validation.data,
     userId: session.user.id,
   });
+
+  // ───────────────────────────────────────────────────────────────
+  // [ECONOMY] Ledger entries for this prediction
+  // ───────────────────────────────────────────────────────────────
+  const userId = session.user.id;
+  const organizationId = session.user.organizationId ?? null;
+
+  // A. Equity: pure cash out (EXPENSE)
+  if (equityInvestment > 0) {
+    await createLedgerEntry({
+      userId,
+      organizationId,
+      kind: LedgerKind.EXPENSE,
+      amountCents: -equityCents, // negative cash movement
+      memo: `Equity investment on forecast ${forecastId}`,
+    });
+  }
+
+  // B. Debt financing: borrow → invest → track liability
+  if (debtFinancing > 0) {
+    // 1) Loan proceeds: cash in
+    await createLedgerEntry({
+      userId,
+      organizationId,
+      kind: LedgerKind.PAYMENT,
+      amountCents: debtCents,
+      memo: `Borrowed $${debtFinancing.toLocaleString()} for forecast ${forecastId}`,
+    });
+
+    // 2) Invest borrowed funds: cash out
+    await createLedgerEntry({
+      userId,
+      organizationId,
+      kind: LedgerKind.EXPENSE,
+      amountCents: -debtCents,
+      memo: `Invested borrowed funds for forecast ${forecastId}`,
+    });
+
+    // 3) Track liability: DEBT, no cash movement
+    await createLedgerEntry({
+      userId,
+      organizationId,
+      kind: LedgerKind.DEBT,
+      amountCents: 0,
+      memo: `Debt opened: $${debtFinancing.toLocaleString()} principal`,
+    });
+  }
 
   // 6. Revalidate cache
   revalidatePath(Router.USER_FORECAST_DETAIL(forecastId));
@@ -197,6 +357,9 @@ export async function updatePredictionAction(
       debtFinancing: validation.data.debtFinancing?.toString() || "",
     });
   }
+
+  // [ECONOMY-TODO] You might later add logic here to diff old vs new
+  // equity/debt and adjust ledger entries accordingly.
 
   // 5. Update prediction
   await updatePrediction(validation.data);


### PR DESCRIPTION
This PR adds the initial wiring for the yFL economy system without changing the database schema.

Key Updates

- Added getUserBalance() and supporting finance helpers (CENTS, createLedgerEntry, ensureStartingBalancesForUser).
- Updated createPredictionAction to include:
- Starting balance seeding ($1B for new users)
- Equity/debt investment validation
- Ledger entry creation for equity (EXPENSE) and debt financing (PAYMENT + EXPENSE + DEBT)
- Added Balance KPI to the User Dashboard using getUserBalance().