### PR TITLE
Remove categories prop from ForecastDetailView component

### DIFF
--- a/src/views/forecasts/ForecastDetailView.tsx
+++ b/src/views/forecasts/ForecastDetailView.tsx
@@ -559,7 +559,6 @@ export default function ForecastDetailView({
         open={showEditModal}
         onOpenChange={setShowEditModal}
         isOrgAdmin={isOrgAdmin}
-        categories={categories}
       />
 
       {/* Set Actual Value Dialog */}


### PR DESCRIPTION
Eliminate the unnecessary categories prop from the ForecastDetailView component to simplify its interface.